### PR TITLE
multiple code improvements: squid:S1854, squid:S1118, squid:S2325

### DIFF
--- a/hexameter-core/src/main/java/org/codetome/hexameter/core/internal/GridData.java
+++ b/hexameter-core/src/main/java/org/codetome/hexameter/core/internal/GridData.java
@@ -39,11 +39,11 @@ public final class GridData {
         this.hexagonWidth = FLAT_TOP.equals(orientation) ? calculateWidth(radius) : calculateHeight(radius);
     }
 
-    private double calculateHeight(final double radius) {
+    private static double calculateHeight(final double radius) {
         return sqrt(3) * radius;
     }
 
-    private double calculateWidth(final double radius) {
+    private static double calculateWidth(final double radius) {
         return radius * 3 / 2;
     }
 }

--- a/hexameter-core/src/main/java/org/codetome/hexameter/core/internal/impl/HexagonalGridImpl.java
+++ b/hexameter-core/src/main/java/org/codetome/hexameter/core/internal/impl/HexagonalGridImpl.java
@@ -125,7 +125,7 @@ public final class HexagonalGridImpl implements HexagonalGrid {
         return gridData;
     }
 
-    private boolean hexagonsAreAtTheSamePosition(final Hexagon hex0, final Hexagon hex1) {
+    private static boolean hexagonsAreAtTheSamePosition(final Hexagon hex0, final Hexagon hex1) {
         return hex0.getGridX() == hex1.getGridX() && hex0.getGridZ() == hex1.getGridZ();
     }
 

--- a/hexameter-examples/hexameter-rest-example/src/main/java/org/codetome/hexameter/restexample/Main.java
+++ b/hexameter-examples/hexameter-rest-example/src/main/java/org/codetome/hexameter/restexample/Main.java
@@ -29,7 +29,11 @@ import static spark.Spark.put;
 
 public class Main {
 
+    private static final String BAD_REQUEST = "Bad request";
+    private static final String APPLICATION_JSON = "application/json";
     private static final int DEFAULT_PORT = 4567;
+
+    private Main() {}
 
     public static void main(String[] args) {
 
@@ -54,7 +58,7 @@ public class Main {
             HexagonBuilderPayload payload = new ObjectMapper().readValue(request.body(), HexagonBuilderPayload.class);
             int id = model.createGrid(payload);
             response.status(201);
-            response.type("application/json");
+            response.type(APPLICATION_JSON);
             return id;
         });
 
@@ -62,13 +66,13 @@ public class Main {
             HexagonBuilderPayload payload = new ObjectMapper().readValue(request.body(), HexagonBuilderPayload.class);
             int id = model.replaceGrid(payload);
             response.status(201);
-            response.type("application/json");
+            response.type(APPLICATION_JSON);
             return id;
         });
 
         get("/grids/getGridForDrawing/:id", (request, response) -> {
             response.status(200);
-            response.type("application/json");
+            response.type(APPLICATION_JSON);
             return dataToJson(GridDto.fromGrid(model.getGridById(parseInt(request.params(":id")))));
         });
 
@@ -80,19 +84,19 @@ public class Main {
         exception(IOException.class, (e, request, response) -> {
             response.status(400);
             logger.error("Fail", e);
-            response.body("Bad request");
+            response.body(BAD_REQUEST);
         });
 
         exception(JsonParseException.class, (e, request, response) -> {
             response.status(400);
             logger.error("Fail", e);
-            response.body("Bad request");
+            response.body(BAD_REQUEST);
         });
 
         exception(JsonMappingException.class, (e, request, response) -> {
             response.status(400);
             logger.error("Fail", e);
-            response.body("Bad request");
+            response.body(BAD_REQUEST);
         });
 
         options("/*",

--- a/hexameter-examples/hexameter-swt-example/src/main/java/org/codetome/hexameter/swtexample/DemoComposite.java
+++ b/hexameter-examples/hexameter-swt-example/src/main/java/org/codetome/hexameter/swtexample/DemoComposite.java
@@ -326,7 +326,7 @@ public class DemoComposite extends Composite {
                     currSelected = hex;
                     drawDistance();
                     Optional<SatelliteDataImpl> dataOptional = hex.<SatelliteDataImpl>getSatelliteData();
-                    SatelliteDataImpl data = null;
+                    SatelliteDataImpl data;
                     if (dataOptional.isPresent()) {
                         data = dataOptional.get();
                     } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 Dead stores should be removed.
squid:S1118 Utility classes should not have public constructors.
squid:S2325 "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1854
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava