### PR TITLE
Adding the satellite data type to the grid returned by the builder.

### DIFF
--- a/hexameter-core/src/main/java/org/codetome/hexameter/core/api/HexagonalGridBuilder.java
+++ b/hexameter-core/src/main/java/org/codetome/hexameter/core/api/HexagonalGridBuilder.java
@@ -36,9 +36,9 @@ public final class HexagonalGridBuilder<T extends SatelliteData> {
      *
      * @return {@link HexagonalGrid}
      */
-    public HexagonalGrid build() {
+    public HexagonalGrid<T> build() {
         checkParameters();
-        return new HexagonalGridImpl(this);
+        return new HexagonalGridImpl<>(this);
     }
 
     private void checkParameters() {


### PR DESCRIPTION
While the HexagonalGridBuilder is generic and takes a type, the build() method doesn't return a grid of that type.  Adding the <T> looked straightforward, and all tests still pass.